### PR TITLE
[build] Fix crane append in Build

### DIFF
--- a/build/action.yml
+++ b/build/action.yml
@@ -43,4 +43,4 @@ runs:
         crane append \
           --oci-empty-base \
           --new_layer "" \
-          --new_tag "${{ inputs.module_source }}/${{ inputs.module_name }}"
+          --new_tag "${{ inputs.module_source }}:${{ inputs.module_name }}"


### PR DESCRIPTION
If we have`  --new_tag "${{ inputs.module_source }}/${{ inputs.module_name }}"`
```
crane manifest ghcr.io/trofimovdals/modules/
Error: fetching manifest ghcr.io/trofimovdals/modules/: GET https://ghcr.io/v2/trofimovdals/modules/manifests/latest: MANIFEST_UNKNOWN: manifest unknown
```
Need change to  `--new_tag "${{ inputs.module_source }}:${{ inputs.module_name }}"`
```
crane ls ghcr.io/trofimovdals/modules/
test-module
```