### PR TITLE
Fix Trivy fail with all severity levels

### DIFF
--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -94,26 +94,18 @@ runs:
           IMAGE_REPORT_NAME="$MODULE_NAME::$IMAGE_NAME"
           # Output reports per images
           echo "    Scanning $IMAGE_REPORT_NAME"
-          echo "additional_image_detected: $additional_image_detected"
-          echo "module_image: $module_image"
-          echo "IMAGE_NAME: $IMAGE_NAME"
-          echo "IMAGE_HASH: $IMAGE_HASH"
-          echo "IMAGE_REPORT_NAME: $IMAGE_REPORT_NAME"
-          echo "MODULE_NAME: $MODULE_NAME"
-          echo "IMAGE: $IMAGE"
-          trivy --version
           if [ "$additional_image_detected" == true ]; then
             echo "starting scan with tag"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE:$TAG"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE:$TAG"
             echo "scan with tag and json - ok"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "$IMAGE:$TAG"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "$IMAGE:$TAG"
             echo "scan with tag and table - ok"
           else
             echo "starting scan with hash"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --debug "$IMAGE@$IMAGE_HASH"
-            echo "scan with hash and json - ok"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --format table --scanners vuln --debug "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --debug "$IMAGE@$IMAGE_HASH"
             echo "scan with hash and table - ok"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --debug "$IMAGE@$IMAGE_HASH"
+            echo "scan with hash and json - ok"
           fi
           echo "    Done"
           echo ""

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -103,14 +103,16 @@ runs:
           echo "IMAGE: $IMAGE"
           trivy --version
           if [ "$additional_image_detected" == true ]; then
+            echo "starting scan with tag"
             trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE:$TAG"
             echo "scan with tag and json - ok"
             trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "$IMAGE:$TAG"
             echo "scan with tag and table - ok"
           else
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" "$IMAGE@$IMAGE_HASH"
+            echo "starting scan with hash"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --debug "$IMAGE@$IMAGE_HASH"
             echo "scan with hash and json - ok"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format table --scanners vuln "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format table --scanners vuln --debug "$IMAGE@$IMAGE_HASH"
             echo "scan with hash and table - ok"
           fi
           echo "    Done"

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -110,9 +110,9 @@ runs:
             echo "scan with tag and table - ok"
           else
             echo "starting scan with hash"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --debug "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --debug "$IMAGE@$IMAGE_HASH"
             echo "scan with hash and json - ok"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --format table --scanners vuln --debug "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --format table --scanners vuln --debug "$IMAGE@$IMAGE_HASH"
             echo "scan with hash and table - ok"
           fi
           echo "    Done"

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -110,9 +110,9 @@ runs:
             echo "scan with tag and table - ok"
           else
             echo "starting scan with hash"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --debug "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --debug "$IMAGE@$IMAGE_HASH"
             echo "scan with hash and json - ok"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --debug "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --ignorefile "out/.trivyignore" --format table --scanners vuln --debug "$IMAGE@$IMAGE_HASH"
             echo "scan with hash and table - ok"
           fi
           echo "    Done"

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -95,17 +95,11 @@ runs:
           # Output reports per images
           echo "    Scanning $IMAGE_REPORT_NAME"
           if [ "$additional_image_detected" == true ]; then
-            echo "starting scan with tag"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE:$TAG"
-            echo "scan with tag and json - ok"
             trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "$IMAGE:$TAG"
-            echo "scan with tag and table - ok"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE:$TAG"
           else
-            echo "starting scan with hash"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --debug "$IMAGE@$IMAGE_HASH"
-            echo "scan with hash and table - ok"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --debug "$IMAGE@$IMAGE_HASH"
-            echo "scan with hash and json - ok"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" "$IMAGE@$IMAGE_HASH"
           fi
           echo "    Done"
           echo ""

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -98,8 +98,8 @@ runs:
             trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "$IMAGE:$TAG"
             trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE:$TAG"
           else
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln "$IMAGE@$IMAGE_HASH"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE@$IMAGE_HASH"
           fi
           echo "    Done"
           echo ""

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -47,7 +47,7 @@ runs:
     - name: Run Trivy CVE Scan
       shell: bash
       env:
-        SEVERITY: "LOW,MEDIUM,HIGH,CRITICAL"
+        SEVERITY: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
         IMAGES_DIGESTS_PATH: "/images_digests.json"
         IMAGE: ${{inputs.image}}
         TAG: ${{inputs.tag}}
@@ -102,6 +102,7 @@ runs:
           echo "MODULE_NAME: $MODULE_NAME"
           echo "IMAGE: $IMAGE"
           trivy --version
+          cat out/.trivyignore
           if [ "$additional_image_detected" == true ]; then
             echo "starting scan with tag"
             trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE:$TAG"
@@ -110,9 +111,9 @@ runs:
             echo "scan with tag and table - ok"
           else
             echo "starting scan with hash"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --debug "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --debug "$IMAGE@$IMAGE_HASH"
             echo "scan with hash and json - ok"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --debug "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --format table --scanners vuln --debug "$IMAGE@$IMAGE_HASH"
             echo "scan with hash and table - ok"
           fi
           echo "    Done"

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -94,6 +94,11 @@ runs:
           IMAGE_REPORT_NAME="$MODULE_NAME::$IMAGE_NAME"
           # Output reports per images
           echo "    Scanning $IMAGE_REPORT_NAME"
+          echo "additional_image_detected: $additional_image_detected"
+          echo "module_image: $module_image"
+          echo "IMAGE_NAME: $IMAGE_NAME"
+          echo "IMAGE_HASH: $IMAGE_HASH"
+          echo "IMAGE_REPORT_NAME: $IMAGE_REPORT_NAME"
           if [ "$additional_image_detected" == true ]; then
             trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE:$TAG"
             trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "$IMAGE:$TAG"

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -47,7 +47,7 @@ runs:
     - name: Run Trivy CVE Scan
       shell: bash
       env:
-        SEVERITY: "HIGH,CRITICAL"
+        SEVERITY: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
         IMAGES_DIGESTS_PATH: "/images_digests.json"
         IMAGE: ${{inputs.image}}
         TAG: ${{inputs.tag}}
@@ -104,15 +104,15 @@ runs:
           trivy --version
           if [ "$additional_image_detected" == true ]; then
             echo "starting scan with tag"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE:$TAG"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE:$TAG"
             echo "scan with tag and json - ok"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "$IMAGE:$TAG"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "$IMAGE:$TAG"
             echo "scan with tag and table - ok"
           else
             echo "starting scan with hash"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --debug "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --debug "$IMAGE@$IMAGE_HASH"
             echo "scan with hash and json - ok"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format table --scanners vuln --debug "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --debug "$IMAGE@$IMAGE_HASH"
             echo "scan with hash and table - ok"
           fi
           echo "    Done"

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -99,12 +99,19 @@ runs:
           echo "IMAGE_NAME: $IMAGE_NAME"
           echo "IMAGE_HASH: $IMAGE_HASH"
           echo "IMAGE_REPORT_NAME: $IMAGE_REPORT_NAME"
+          echo "MODULE_NAME: $MODULE_NAME"
+          echo "IMAGE: $IMAGE"
+          trivy --version
           if [ "$additional_image_detected" == true ]; then
             trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE:$TAG"
+            echo "scan with tag and json - ok"
             trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "$IMAGE:$TAG"
+            echo "scan with tag and table - ok"
           else
             trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE@$IMAGE_HASH"
+            echo "scan with hash and json - ok"
             trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "$IMAGE@$IMAGE_HASH"
+            echo "scan with hash and table - ok"
           fi
           echo "    Done"
           echo ""

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -108,9 +108,9 @@ runs:
             trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "$IMAGE:$TAG"
             echo "scan with tag and table - ok"
           else
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" "$IMAGE@$IMAGE_HASH"
             echo "scan with hash and json - ok"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity=$SEVERITY --ignorefile "out/.trivyignore" --format table --scanners vuln "$IMAGE@$IMAGE_HASH"
             echo "scan with hash and table - ok"
           fi
           echo "    Done"

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -47,7 +47,7 @@ runs:
     - name: Run Trivy CVE Scan
       shell: bash
       env:
-        SEVERITY: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+        SEVERITY: "LOW,MEDIUM,HIGH,CRITICAL"
         IMAGES_DIGESTS_PATH: "/images_digests.json"
         IMAGE: ${{inputs.image}}
         TAG: ${{inputs.tag}}
@@ -110,9 +110,9 @@ runs:
             echo "scan with tag and table - ok"
           else
             echo "starting scan with hash"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --debug "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --debug "$IMAGE@$IMAGE_HASH"
             echo "scan with hash and json - ok"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --ignorefile "out/.trivyignore" --format table --scanners vuln --debug "$IMAGE@$IMAGE_HASH"
+            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --debug "$IMAGE@$IMAGE_HASH"
             echo "scan with hash and table - ok"
           fi
           echo "    Done"

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -47,7 +47,7 @@ runs:
     - name: Run Trivy CVE Scan
       shell: bash
       env:
-        SEVERITY: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+        SEVERITY: "HIGH,CRITICAL"
         IMAGES_DIGESTS_PATH: "/images_digests.json"
         IMAGE: ${{inputs.image}}
         TAG: ${{inputs.tag}}

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -102,7 +102,6 @@ runs:
           echo "MODULE_NAME: $MODULE_NAME"
           echo "IMAGE: $IMAGE"
           trivy --version
-          cat out/.trivyignore
           if [ "$additional_image_detected" == true ]; then
             echo "starting scan with tag"
             trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE:$TAG"


### PR DESCRIPTION
For some reason, if all severity levels defined - Trivy fails if vulnerabilities are found despite docs says "By default, Trivy exits with code 0 even when vulnerabilities are detected". So added explicitly --exit-code 0