### PR TITLE
fix trivy download

### DIFF
--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -35,15 +35,16 @@ runs:
     - name: Get Trivy
       shell: bash
       env:
-        TRIVY_BIN_VERSION: "0.55.0"
+        TRIVY_BIN_VERSION: "v0.58.1"
         TRIVY_REPO_ID: "2181"
         DECKHOUSE_PRIVATE_REPO: ${{inputs.deckhouse_private_repo}}
       run: |
         echo "Get Trivy"
         mkdir -p bin/trivy-${TRIVY_BIN_VERSION}
-        curl https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_REPO_ID}/packages/generic/deckhouse-trivy/v${TRIVY_BIN_VERSION}/trivy -o bin/trivy-${TRIVY_BIN_VERSION}/trivy
+        curl https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_REPO_ID}/packages/generic/trivy-${TRIVY_BIN_VERSION}/${TRIVY_BIN_VERSION}/trivy -o bin/trivy-${TRIVY_BIN_VERSION}/trivy
         chmod u+x bin/trivy-${TRIVY_BIN_VERSION}/trivy
         echo "${PWD}/bin/trivy-${TRIVY_BIN_VERSION}" >> $GITHUB_PATH
+        bin/trivy-${TRIVY_BIN_VERSION}/trivy clean --all
     - name: Run Trivy CVE Scan
       shell: bash
       env:
@@ -76,6 +77,7 @@ runs:
         echo "Images to scan:"
         echo "$digests"
         mkdir -p out/json
+        touch out/.trivyignore
         date_iso=$(date -I)
         for module_image in $(jq -rc 'to_entries[]' <<< "$digests"); do
           IMAGE_NAME=$(jq -rc '.key' <<< "$module_image")


### PR DESCRIPTION
### What was changed

- Updated Trivy version to `v0.58.1`
- Added `trivy clean --all` step to clear the cache
- Added a step to create an empty `.trivyignore` file (required in the new version)

These changes are required for the updated Trivy version to work correctly.


I tested it here: https://github.com/deckhouse/sds-local-volume/actions/runs/14196172425/job/39772137774