### PR TITLE
CVE scheduled scan

### DIFF
--- a/.docs/cve_scan.md
+++ b/.docs/cve_scan.md
@@ -29,14 +29,23 @@ severity - Optional. Vulnerabilities severity to scan. Default is: UNKNOWN,LOW,M
 ```
 tag - module image tag
 module_name - module name
+dd_url - URL to defectDojo
+dd_token - token of defectDojo to upload reports
+deckhouse_private_repo - url to private repo
+prod_registry - Must be deckhouse prod registry, used to get trivy databases and release images
+prod_registry_user - Username to log in to deckhouse prod registry
+prod_registry_password - Password to log in to deckhouse prod registry
+dev_registry - Must be deckhouse dev registry, used to get dev images
+dev_registry_user - Username to log in to deckhouse dev registry
+dev_registry_password - Password to log in to deckhouse dev registry
 ```
 #### Optional
 ```
-  scan_several_lastest_releases - true/false. Whether to scan last several releases or not. For scheduled pipelines override will not work as value is always true
-  latest_releases_amount - Number of latest minor releases to scan. Latest patch versions of latest N minor versions will be taken. Default is: 3
-  severity - Vulnerabilities severity to scan. Default is: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
-  module_prod_registry_custom_path - Module custom path in prod registry. Example: flant/modules
-  module_dev_registry_custom_path - Module custom path in dev registry. Example: flant/modules
+scan_several_lastest_releases - true/false. Whether to scan last several releases or not. For scheduled pipelines override will not work as value is always true
+latest_releases_amount - Number of latest minor releases to scan. Latest patch versions of latest N minor versions will be taken. Default is: 3
+severity - Vulnerabilities severity to scan. Default is: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+module_prod_registry_custom_path - Module custom path in prod registry. Example: flant/modules
+module_dev_registry_custom_path - Module custom path in dev registry. Example: flant/modules
 ```
 
 ### GitHub Masked variables

--- a/.docs/cve_scan.md
+++ b/.docs/cve_scan.md
@@ -11,6 +11,7 @@ CI Use cases:
 - Manual scan
   - Scan specified release by entering semver minor version of target release in *release_branch* variable.
   - Scan main branch and several latest releases by setting *scan_several_lastest_releases* to "true" and optionally defining amount of latest minor releases by setting a number into *latest_releases_amount* variable.
+  - Scan only main branch just by running pipeline
 
 ## Variables
 

--- a/.docs/cve_scan.md
+++ b/.docs/cve_scan.md
@@ -1,42 +1,127 @@
 # CVE Scan CI Integration
 
 ## Description
-This CI file will run a Trivy CVE scan against the module images and its submodule images, and then upload the reports to DefectDojo.
+This CI file will run a Trivy CVE scan against the module images and its submodule images, and then upload the reports to DefectDojo.  
+The script will detect release or dev tag of module image is used and then construct registry location by itself. If your module located in registries by not standart paths - you may want to define custom path by *module_prod_registry_custom_path* and *module_dev_registry_custom_path* variables.  
+CI Use cases:  
+- Scan by scheduler
+  - Scan main branch and several latest releases 2-3 times a week
+- Scan on PR
+  - Scan images on pull request to check if no new vulnerabilities are present or to ensure if they are closed.
+- Manual scan
+  - Scan specified release by entering semver minor version of target release in *release_branch* variable.
+  - Scan main branch and several latest releases by setting *scan_several_lastest_releases* to "true" and optionally defining amount of latest minor releases by setting a number into *latest_releases_amount* variable.
 
 ## Variables
 
-### Job level
+### workflow_dispatch level
 ```
-image - URL to a registry image, e.g., registry.example.com/deckhouse/modules/module_name
+release_branch - Optional. Set minor version of release you want to scan. e.g.: 1.23
+scan_several_lastest_releases - Optional. Whether to scan last several releases or not. true/false. For scheduled pipelines it is always true. Default is: false.
+latest_releases_amount - Optional. Number of latest releases to scan. Default is: 3
+severity - Optional. Vulnerabilities severity to scan. Default is: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+```
+
+### Job level
+
+#### Mandatory
+```
 tag - module image tag
 module_name - module name
+```
+#### Optional
+```
+  scan_several_lastest_releases - true/false. Whether to scan last several releases or not. For scheduled pipelines override will not work as value is always true
+  latest_releases_amount - Number of latest minor releases to scan. Latest patch versions of latest N minor versions will be taken. Default is: 3
+  severity - Vulnerabilities severity to scan. Default is: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+  module_prod_registry_custom_path - Module custom path in prod registry. Example: flant/modules
+  module_dev_registry_custom_path - Module custom path in dev registry. Example: flant/modules
 ```
 
 ### GitHub Masked variables
 ```
 dd_url - URL to defectDojo
 dd_token - token of defectDojo to upload reports
-trivy_registry - must be deckhouse prod registry, used to get trivy databases
-trivy_registry_user - username to log in to deckhouse prod registry
-trivy_registry_password - password to log in to deckhouse prod registry
 deckhouse_private_repo - url to private repo
+prod_registry - Must be deckhouse prod registry, used to get trivy databases and release images
+prod_registry_user - Username to log in to deckhouse prod registry
+prod_registry_password - Password to log in to deckhouse prod registry
+dev_registry - Must be deckhouse dev registry, used to get dev images
+dev_registry_user - Username to log in to deckhouse dev registry
+dev_registry_password - Password to log in to deckhouse dev registry
 ```
 
 ## How to include
 
-Put the following step of job into required place of you GitHub Action file (usually after build step/job if exist):  
+Set trigger rules with scheduler, manual and pull requests in your cve scan CI file:  
 ```
-      - uses: deckhouse/modules-actions/cve_scan@cve_scan_ci
+on:
+  schedule:
+    - cron: '0 01 * * 0,3'
+  pull_request:
+    types: [opened, reopened, labeled, synchronize]
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: 'Optional. Set minor version of release you want to scan. e.g.: 1.23'
+        required: false
+      scan_several_lastest_releases:
+        description: 'Optional. Whether to scan last several releases or not. true/false. For scheduled pipelines it is always true. Default is: false.'
+        required: false
+      latest_releases_amount:
+        description: 'Optional. Number of latest releases to scan. Default is: 3'
+        required: false
+      severity:
+        description: 'Optional. Vulnerabilities severity to scan. Default is: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+        required: false
+```
+
+Put the following jobs into required place of you GitHub Action file (usually after build step/job if exist):  
+```
+  cve_scan_on_pr:
+    if: github.event_name == 'pull_request'
+    name: CVE scan for PR
+    needs: [build_dev]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: deckhouse/modules-actions/cve_scan@chore/cve_scheduled_scan
         with:
-          image: registry.example.com/path/to/module
-          tag: module_image_tag
-          module_name: module_name
-          dd_url: ${{secrets.DEFECTDOJO_HOST}}
-          dd_token: ${{secrets.DEFECTDOJO_API_TOKEN}}
-          trivy_registry: ${{ vars.PROD_REGISTRY }}
-          trivy_registry_user: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
-          trivy_registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}
-          deckhouse_private_repo: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
+          tag: pr${{ github.event.number }}
+          module_name: ${{ vars.MODULE_NAME }}
+          dd_url: ${{ secrets.DEFECTDOJO_HOST }}
+          dd_token: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+          prod_registry: ${{ secrets.PROD_READ_REGISTRY }}
+          prod_registry_user: ${{ secrets.PROD_MODULES_READ_REGISTRY_USER }}
+          prod_registry_password: ${{ secrets.PROD_MODULES_READ_REGISTRY_PASSWORD }}
+          dev_registry: ${{ vars.DEV_REGISTRY }}
+          dev_registry_user: ${{ vars.DEV_MODULES_REGISTRY_USER }}
+          dev_registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
+          deckhouse_private_repo: ${{ secrets.DECKHOUSE_PRIVATE_REPO }}
+  cve_scan:
+    if: github.event_name != 'pull_request'
+    name: Regular CVE scan
+    steps:
+      - uses: actions/checkout@v4
+      - uses: deckhouse/modules-actions/cve_scan@chore/cve_scheduled_scan
+        with:
+          tag: ${{ github.event.inputs.release_branch || github.event.repository.default_branch }}
+          module_name: ${{ vars.MODULE_NAME }}
+          dd_url: ${{ secrets.DEFECTDOJO_HOST }}
+          dd_token: ${{ secrets.DEFECTDOJO_API_TOKEN }}
+          prod_registry: ${{ secrets.PROD_READ_REGISTRY }}
+          prod_registry_user: ${{ secrets.PROD_MODULES_READ_REGISTRY_USER }}
+          prod_registry_password: ${{ secrets.PROD_MODULES_READ_REGISTRY_PASSWORD }}
+          dev_registry: ${{ vars.DEV_REGISTRY }}
+          dev_registry_user: ${{ vars.DEV_MODULES_REGISTRY_USER }}
+          dev_registry_password: ${{ secrets.DEV_MODULES_REGISTRY_PASSWORD }}
+          deckhouse_private_repo: ${{ secrets.DECKHOUSE_PRIVATE_REPO }}
+          scan_several_lastest_releases: ${{ github.event.inputs.scan_several_lastest_releases }}
+          latest_releases_amount: ${{ github.event.inputs.latest_releases_amount || '3' }}
+          severity: ${{ github.event.inputs.severity }}
 ```
 
 Usage example can be found [here](../.examples/cve_scan.yml)
+

--- a/.examples/cve_scan.yml
+++ b/.examples/cve_scan.yml
@@ -26,7 +26,6 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
       - uses: deckhouse/modules-actions/cve_scan@v1
         with:
-          image: registry.example.com/deckhouse/modules/module_name
           tag: ${{ env.MODULE_IMAGE_TAG || 'main' }}
           module_name: your-module
           dd_url: ${{secrets.DEFECTDOJO_HOST}}

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -121,15 +121,15 @@ runs:
           echo "Getting module image"
           crane export "${module_image}:${module_tag}" "${MODULE_NAME}.tar"
           mkdir "$MODULE_NAME"
-          tar xf "${MODULE_NAME}.tar" -C "${MODULE_NAME}/"
+          tar xf "${MODULE_NAME}.tar" -C "${module_workdir}/"
           echo "Preparing images list to scan"
-          digests=$(cat "${MODULE_NAME}${IMAGES_DIGESTS_PATH}")
+          digests=$(cat "${module_workdir}${IMAGES_DIGESTS_PATH}")
           # Main module images to scan
           digests=$(echo "$digests"|jq --arg i "$MODULE_NAME" --arg s "${module_tag}" '. += { ($i): ($s) }')
           echo "Images to scan:"
           echo "$digests"
           mkdir -p out/json
-          touch out/.trivyignore
+          touch ${module_workdir}/.trivyignore
           date_iso=$(date -I)
           while read -r line; do
             IMAGE_NAME=$(jq -rc '.key' <<< "${line}")
@@ -138,26 +138,26 @@ runs:
             fi
             # Set flag if additional image to use tag instead of hash
             additional_image_detected=false
-            if [ "$module_image" == "$MODULE_NAME" ]; then
+            if [ "${IMAGE_NAME}" == "${MODULE_NAME}" ]; then
               additional_image_detected=true
             fi
             echo "----------------------------------------------"
-            echo "👾 Image: $module_image"
+            echo "👾 Image: ${IMAGE_NAME}"
             echo ""
             IMAGE_HASH="$(jq -rc '.value' <<< "$line")"
-            IMAGE_REPORT_NAME="$MODULE_NAME::$module_image"
+            IMAGE_REPORT_NAME="${MODULE_NAME}::${IMAGE_NAME}"
             # Output reports per images
             echo "    Scanning $IMAGE_REPORT_NAME"
             if [ "$additional_image_detected" == true ]; then
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}"
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${module_image}_report.json" --quiet "${module_image}:${module_tag}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${IMAGE_NAME}:${module_tag}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${IMAGE_NAME}:${module_tag}"
             else
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}"
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${module_image}_report.json" --quiet "${module_image}@${IMAGE_HASH}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${IMAGE_NAME}@${IMAGE_HASH}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${IMAGE_NAME}@${IMAGE_HASH}"
             fi
             echo "    Done"
             echo ""
-            echo " Uploading trivy CVE report for image ${module_image} of ${MODULE_NAME} module"
+            echo " Uploading trivy CVE report for image ${IMAGE_NAME} of ${MODULE_NAME} module"
             echo ""
             curl -s -X POST \
               ${DD_URL}/api/v2/reimport-scan/ \
@@ -172,16 +172,16 @@ runs:
               -F "close_old_findings=true" \
               -F "do_not_reactivate=false" \
               -F "push_to_jira=false" \
-              -F "file=@out/json/d8_${MODULE_NAME}_${module_image}_report.json" \
+              -F "file=@out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" \
               -F "product_type_name=Deckhouse images" \
               -F "product_name=$MODULE_NAME" \
               -F "scan_date=${date_iso}" \
               -F "engagement_name=CVE Test: ${MODULE_NAME} Images" \
-              -F "service=${MODULE_NAME} / ${module_image}" \
+              -F "service=${MODULE_NAME} / ${IMAGE_NAME}" \
               -F "group_by=component_name+component_version" \
               -F "deduplication_on_engagement=false" \
-              -F "tags=deckhouse_module,module:${MODULE_NAME},image:${module_image},branch:${module_tag}" \
-              -F "test_title=[${MODULE_NAME}]: ${module_image}:${module_tag}" \
+              -F "tags=deckhouse_module,module:${MODULE_NAME},image:${IMAGE_NAME},branch:${module_tag}" \
+              -F "test_title=[${MODULE_NAME}]: ${IMAGE_NAME}:${module_tag}" \
               -F "version=${module_tag}" \
               -F "build_id=${IMAGE_HASH}" \
               -F "commit_hash=${CI_COMMIT_SHA}" \

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -1,9 +1,6 @@
 name: 'Trivy CVE Scan'
 description: 'Build Deckhouse module'
 inputs:
-  image:
-    description: 'URL to a registry image, e.g., registry.example.com/deckhouse/modules/module_name'
-    required: true
   tag:
     description: 'Module image tag'
     required: true
@@ -46,6 +43,12 @@ inputs:
   severity:
     description: 'Vulnerabilities severity to scan. Default is: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
     required: false
+  module_prod_registry_custom_path:
+    description: 'Module custom path in prod registry. Example: flant/modules'
+    required: false
+  module_dev_registry_custom_path:
+    description: 'Module custom path in dev registry. Example: flant/modules'
+    required: false
 
 runs:
   using: "composite"
@@ -73,23 +76,26 @@ runs:
       shell: bash
       env:
         IMAGES_DIGESTS_PATH: "/images_digests.json"
-        IMAGE: "${{inputs.image}}"
         TAG: "${{inputs.tag}}"
         MODULE_NAME: "${{inputs.module_name}}"
         DD_URL: "${{inputs.dd_url}}"
         DD_TOKEN: "${{inputs.dd_token}}"
-        PROD_REGISTRY_MODULE_BASEDIR: "${{inputs.prod_registry}}/deckhouse/fe/modules"
-        DEV_REGISTRY_MODULE_BASEDIR: "${{inputs.dev_registry}}/sys/deckhouse-oss/modules"
         TRIVY_DB_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-db:2"
         TRIVY_JAVA_DB_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-java-db:1"
         TRIVY_POLICY_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-bdu:1"
         SCAN_SEVERAL_LASTEST_RELEASES: "${{inputs.scan_several_lastest_releases}}"
         LATEST_RELEASES_AMOUNT: "${{inputs.latest_releases_amount || '3'}}"
         SEVERITY: "${{inputs.severity || 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'}}"
+        MODULE_PROD_REGISTRY_PATH: "${{inputs.module_prod_registry_custom_path || 'deckhouse/fe/modules'}}"
+        MODULE_DEV_REGISTRY_PATH: "${{inputs.module_dev_registry_custom_path || 'sys/deckhouse-oss/modules'}}"
       run: |
         if [ "${{ github.event_name }}" == "schedule" ]; then
           SCAN_SEVERAL_LASTEST_RELEASES="true"
         fi
+
+        echo "Setting up registry path for module"
+        PROD_REGISTRY_MODULE_BASEDIR="${{inputs.prod_registry}}/${MODULE_PROD_REGISTRY_PATH}"
+        DEV_REGISTRY_MODULE_BASEDIR="${{inputs.dev_registry}}/${MODULE_DEV_REGISTRY_PATH}"
 
         echo "Getting tags to scan"
         module_tags=("${TAG}")
@@ -116,6 +122,9 @@ runs:
 
         echo "CVE Scan will be applied to the following tags of ${MODULE_NAME}"
         echo "${module_tags[*]}"
+        workdir="trivy_scan"
+        # remove workdir in case it was not removed on previous run
+        rm -rf "${workdir}"
         # Scan in loop for provided list of tags
         for module_tag in ${module_tags[*]}; do
           dd_short_release_tag=""
@@ -129,7 +138,6 @@ runs:
             dd_full_release_tag="image_release_tag:${module_tag}"
             dd_image_version="$(echo ${dd_short_release_tag} | sed 's/^release\://')"
           fi
-          workdir="trivy_scan"
           module_workdir="${workdir}/${MODULE_NAME}_${module_tag}"
           module_reports="${module_workdir}/reports"
           mkdir -p "${module_reports}"

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -95,7 +95,7 @@ runs:
         ln -s ${PWD}/${workdir}/bin/trivy-${TRIVY_BIN_VERSION}/trivy ${workdir}/bin/trivy
 
         echo "Updating Trivy Data Bases"
-        mkdir -p "cve_scan/bin/trivy_cache"
+        mkdir -p "${workdir}/bin/trivy_cache"
         ${workdir}/bin/trivy-${TRIVY_BIN_VERSION}/trivy image --download-db-only --db-repository "${TRIVY_DB_URL}" --cache-dir "${workdir}/bin/trivy_cache"
         ${workdir}/bin/trivy-${TRIVY_BIN_VERSION}/trivy image --download-java-db-only --java-db-repository "${TRIVY_JAVA_DB_URL}" --cache-dir "${workdir}/bin/trivy_cache"
         echo

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -68,10 +68,9 @@ runs:
         echo "Get Trivy"
         echo "Trivy version: ${TRIVY_BIN_VERSION}"
         mkdir -p cve_scan/bin/trivy-${TRIVY_BIN_VERSION}
-        curl -s --fail-with-body https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_REPO_ID}/packages/generic/trivy-${TRIVY_BIN_VERSION}/${TRIVY_BIN_VERSION}/trivy -o bin/trivy-${TRIVY_BIN_VERSION}/trivy
+        curl -s --fail-with-body https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_REPO_ID}/packages/generic/trivy-${TRIVY_BIN_VERSION}/${TRIVY_BIN_VERSION}/trivy -o cve_scan/bin/trivy-${TRIVY_BIN_VERSION}/trivy
         chmod u+x cve_scan/bin/trivy-${TRIVY_BIN_VERSION}/trivy
         echo "${PWD}/cve_scan/bin/trivy-${TRIVY_BIN_VERSION}" >> $GITHUB_PATH
-        cve_scan/bin/trivy-${TRIVY_BIN_VERSION}/trivy clean --all
 
         echo "Updating Trivy Data Bases"
         mkdir -p "cve_scan/bin/trivy_cache"

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -89,9 +89,10 @@ runs:
         echo "Getting tags to scan"
         if [ "${{ inputs.scan_three_last_releases }}" == "true" ]; then
           # Get release tags by regexp, sort by sevmer desc, cut to get minor version, uniq and get 3 latest
-          latest_minor_releases=($(crane ls "${PROD_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}" | grep "v[0-9]*\." | sort -V -r | cut -d "-" -f 1|cut -d "." -f -2 | uniq| head -n 3))
-          for r in ${latest_minor_releases[*]}; do
-            module_tags+=($(crane ls "${PROD_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}" | grep "${r}" | sort -V -r|head -n 1))
+          releases=($(crane ls "${PROD_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}" | grep "^v[0-9]*\.[0-9]*\.[0-9]*" | sort -V -r))
+          latest_minor_releases=($(printf '%s\n' "${releases[@]}"| cut -d "." -f -2 | uniq | head -n 3))
+          for r in "${latest_minor_releases[@]}"; do
+            module_tags+=($(printf '%s\n' "${releases[@]}" | grep "${r}" | sort -V -r|head -n 1))
           done
         fi
 
@@ -99,19 +100,20 @@ runs:
         echo "${module_tags[*]}"
         # Scan in loop for provided list of tags
         for module_tag in ${module_tags[*]}; do
+          dd_short_release_tag=""
+          dd_full_release_tag=""
+          dd_image_version="${module_tag}"
+          module_image="${DEV_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}"
           # If we are scanning release images - we need to redefine image path to prod registry
-          if [ "${module_tag}" == "${TAG}" ]; then
-            module_image="${IMAGE}"
-          # if branch is main and pipeline was triggereg by schedule or manually - use dev registry
-          elif [[ "${module_tag}" == "${{ github.event.repository.default_branch }}" ]] && [[ "${{ github.event_name }}" != "pull_request" ]]; then
-            module_image="${DEV_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}"
-          else
+          if echo "${module_tag}" | grep -s "^v[0-9]*\.[0-9]*\.[0-9]*" && [[ "${{ github.event_name }}" != "pull_request" ]]; then
             module_image="${PROD_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}"
+            dd_short_release_tag="release:$(echo ${module_tag} | cut -d '.' -f -2 | sed 's/^v//')"
+            dd_full_release_tag="image_release_tag:${module_tag}"
+            dd_image_version="$(echo ${dd_short_release_tag} | sed 's/^release\://')"
           fi
           workdir="trivy_scan"
           module_workdir="${workdir}/${MODULE_NAME}_${module_tag}"
-          module_reports="${workdir}/${MODULE_NAME}_${module_tag}/reports"
-          mkdir -p "${module_workdir}"
+          module_reports="${module_workdir}/reports"
           mkdir -p "${module_reports}"
           touch ${module_workdir}/.trivyignore
           echo "Run Trivy scan"
@@ -157,7 +159,9 @@ runs:
             echo ""
             echo " Uploading trivy CVE report for image ${IMAGE_NAME} of ${MODULE_NAME} module"
             echo ""
-            curl -s -X POST \
+            curl -X POST \
+              --retry 3 \
+              --retry-delay 5 \
               ${DD_URL}/api/v2/reimport-scan/ \
               -H "accept: application/json" \
               -H "Content-Type: multipart/form-data"  \
@@ -178,9 +182,9 @@ runs:
               -F "service=${MODULE_NAME} / ${IMAGE_NAME}" \
               -F "group_by=component_name+component_version" \
               -F "deduplication_on_engagement=false" \
-              -F "tags=deckhouse_module,module:${MODULE_NAME},image:${IMAGE_NAME},branch:${module_tag}" \
+              -F "tags=deckhouse_module,module:${MODULE_NAME},image:${IMAGE_NAME},branch:${module_tag},${dd_short_release_tag},${dd_full_release_tag}" \
               -F "test_title=[${MODULE_NAME}]: ${IMAGE_NAME}:${module_tag}" \
-              -F "version=${module_tag}" \
+              -F "version=${dd_image_version}" \
               -F "build_id=${IMAGE_HASH}" \
               -F "commit_hash=${CI_COMMIT_SHA}" \
               -F "branch_tag=${module_tag}" \

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -121,7 +121,6 @@ runs:
           echo ""
           echo "Getting module image"
           crane export "${module_image}:${module_tag}" "${MODULE_NAME}.tar"
-          mkdir "$MODULE_NAME"
           tar xf "${MODULE_NAME}.tar" -C "${module_workdir}/"
           echo "Preparing images list to scan"
           digests=$(cat "${module_workdir}${IMAGES_DIGESTS_PATH}")

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -145,9 +145,9 @@ runs:
           echo "Preparing images list to scan"
           digests=$(cat "${module_workdir}${IMAGES_DIGESTS_PATH}")
           # Main module images to scan
-          digests=$(echo "$digests"|jq --arg i "$MODULE_NAME" --arg s "${module_tag}" '. += { ($i): ($s) }')
+          digests=$(echo "${digests}"|jq --arg i "${MODULE_NAME}" --arg s "${module_tag}" '. += { ($i): ($s) }')
           echo "Images to scan:"
-          echo "$digests"
+          echo "${digests}"
           date_iso=$(date -I)
           while read -r line; do
             IMAGE_NAME=$(jq -rc '.key' <<< "${line}")
@@ -165,11 +165,11 @@ runs:
             IMAGE_HASH="$(jq -rc '.value' <<< "$line")"
 
             if [ "$additional_image_detected" == true ]; then
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}"
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}:${module_tag}"
+              trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}"
+              trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}:${module_tag}"
             else
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}"
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}@${IMAGE_HASH}"
+              trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}"
+              trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}@${IMAGE_HASH}"
             fi
             echo "    Done"
             echo ""

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -63,6 +63,7 @@ runs:
         DECKHOUSE_PRIVATE_REPO: ${{inputs.deckhouse_private_repo}}
       run: |
         echo "Get Trivy"
+        echo "Trivy version: ${TRIVY_BIN_VERSION}"
         mkdir -p bin/trivy-${TRIVY_BIN_VERSION}
         curl -s --fail-with-body https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_REPO_ID}/packages/generic/trivy-${TRIVY_BIN_VERSION}/${TRIVY_BIN_VERSION}/trivy -o bin/trivy-${TRIVY_BIN_VERSION}/trivy
         chmod u+x bin/trivy-${TRIVY_BIN_VERSION}/trivy

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -96,8 +96,8 @@ runs:
 
         echo "Updating Trivy Data Bases"
         mkdir -p "${workdir}/bin/trivy_cache"
-        ${workdir}/bin/trivy-${TRIVY_BIN_VERSION}/trivy image --download-db-only --db-repository "${TRIVY_DB_URL}" --cache-dir "${workdir}/bin/trivy_cache"
-        ${workdir}/bin/trivy-${TRIVY_BIN_VERSION}/trivy image --download-java-db-only --java-db-repository "${TRIVY_JAVA_DB_URL}" --cache-dir "${workdir}/bin/trivy_cache"
+        ${workdir}/bin/trivy image --download-db-only --db-repository "${TRIVY_DB_URL}" --cache-dir "${workdir}/bin/trivy_cache"
+        ${workdir}/bin/trivy image --download-java-db-only --java-db-repository "${TRIVY_JAVA_DB_URL}" --cache-dir "${workdir}/bin/trivy_cache"
         echo
         echo "======================================================="
         echo

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -16,22 +16,39 @@ inputs:
   dd_token:
     description: 'token of defectDojo to upload reports'
     required: true
-  trivy_registry:
-    description: 'must be deckhouse prod registry, used to get trivy databases'
+  prod_registry:
+    description: 'must be deckhouse prod registry, used to get trivy databases and release images'
     required: true
-  trivy_registry_user:
+  prod_registry_user:
     description: 'username to log in to deckhouse prod registry'
     required: true
-  trivy_registry_password:
+  prod_registry_password:
     description: 'password to log in to deckhouse prod registry'
+    required: true
+  dev_registry:
+    description: ' must be deckhouse dev registry, used to get dev images'
+    required: true
+  dev_registry_user:
+    description: 'username to log in to deckhouse dev registry'
+    required: true
+  dev_registry_password:
+    description: 'password to log in to deckhouse dev registry'
     required: true
   deckhouse_private_repo:
     description: 'url to private repo'
     required: true
+  scan_three_last_releases:
+    description: 'whether to scan last 3 releases or not. useful for scheduled task'
+    required: false
 
 runs:
   using: "composite"
   steps:
+    - name: Login to registries
+      shell: bash
+      run: |
+        echo ${{inputs.prod_registry_password}} | docker login --username="${{inputs.prod_registry_user}}" --password-stdin ${{inputs.prod_registry}}
+        echo ${{inputs.dev_registry_password}} | docker login --username="${{inputs.dev_registry_user}}" --password-stdin ${{inputs.dev_registry}}
     - name: Get Trivy
       shell: bash
       env:
@@ -41,99 +58,131 @@ runs:
       run: |
         echo "Get Trivy"
         mkdir -p bin/trivy-${TRIVY_BIN_VERSION}
-        curl https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_REPO_ID}/packages/generic/trivy-${TRIVY_BIN_VERSION}/${TRIVY_BIN_VERSION}/trivy -o bin/trivy-${TRIVY_BIN_VERSION}/trivy
+        curl -s --fail-with-body https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_REPO_ID}/packages/generic/trivy-${TRIVY_BIN_VERSION}/${TRIVY_BIN_VERSION}/trivy -o bin/trivy-${TRIVY_BIN_VERSION}/trivy
         chmod u+x bin/trivy-${TRIVY_BIN_VERSION}/trivy
         echo "${PWD}/bin/trivy-${TRIVY_BIN_VERSION}" >> $GITHUB_PATH
         bin/trivy-${TRIVY_BIN_VERSION}/trivy clean --all
     - name: Run Trivy CVE Scan
       shell: bash
       env:
-        SEVERITY: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+        SEVERITY: "HIGH,CRITICAL"
         IMAGES_DIGESTS_PATH: "/images_digests.json"
-        IMAGE: ${{inputs.image}}
-        TAG: ${{inputs.tag}}
-        MODULE_NAME: ${{inputs.module_name}}
-        DD_URL: ${{inputs.dd_url}}
-        DD_TOKEN: ${{inputs.dd_token}}
-        TRIVY_REGISTRY_USER: ${{inputs.trivy_registry_user}}
-        TRIVY_REGISTRY_PASSWORD: ${{inputs.trivy_registry_password}}
-        TRIVY_DB_URL: ${{inputs.trivy_registry}}/deckhouse/ee/security/trivy-db:2
-        TRIVY_JAVA_DB_URL: ${{inputs.trivy_registry}}/deckhouse/ee/security/trivy-java-db:1
-        TRIVY_POLICY_URL: ${{inputs.trivy_registry}}/deckhouse/ee/security/trivy-bdu:1
+        IMAGE: "${{inputs.image}}"
+        TAG: "${{inputs.tag}}"
+        MODULE_NAME: "${{inputs.module_name}}"
+        DD_URL: "${{inputs.dd_url}}"
+        DD_TOKEN: "${{inputs.dd_token}}"
+        PROD_REGISTRY_MODULE_BASEDIR: "${{inputs.prod_registry}}/deckhouse/fe/modules"
+        DEV_REGISTRY_MODULE_BASEDIR: "${{inputs.dev_registry}}/sys/deckhouse-oss/modules"
+        TRIVY_DB_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-db:2"
+        TRIVY_JAVA_DB_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-java-db:1"
+        TRIVY_POLICY_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-bdu:1"
       run: |
-        echo "Run Trivy scan"
-        echo "Image to check: $IMAGE:$TAG"
-        echo "Severity: $SEVERITY"
-        echo "----------------------------------------------"
-        echo ""
-        echo "Getting module image"
-        crane export "$IMAGE:$TAG" "${MODULE_NAME}.tar"
-        mkdir "$MODULE_NAME"
-        tar xf "${MODULE_NAME}.tar" -C "${MODULE_NAME}/"
-        echo "Preparing images list to scan"
-        digests=$(cat "${MODULE_NAME}${IMAGES_DIGESTS_PATH}")
-        # Main module images to scan
-        digests=$(echo "$digests"|jq --arg i "$MODULE_NAME" --arg s "$TAG" '. += { ($i): ($s) }')
-        echo "Images to scan:"
-        echo "$digests"
-        mkdir -p out/json
-        touch out/.trivyignore
-        date_iso=$(date -I)
-        for module_image in $(jq -rc 'to_entries[]' <<< "$digests"); do
-          IMAGE_NAME=$(jq -rc '.key' <<< "$module_image")
-          if [[ "$IMAGE_NAME" == "trivy" ]]; then
-            continue
-          fi
-          # Set flag if additional image to use tag instead of hash
-          additional_image_detected=false
-          if [ "$IMAGE_NAME" == "$MODULE_NAME" ]; then
-            additional_image_detected=true
-          fi
-          echo "----------------------------------------------"
-          echo "👾 Image: $IMAGE_NAME"
-          echo ""
-          IMAGE_HASH="$(jq -rc '.value' <<< "$module_image")"
-          IMAGE_REPORT_NAME="$MODULE_NAME::$IMAGE_NAME"
-          # Output reports per images
-          echo "    Scanning $IMAGE_REPORT_NAME"
-          if [ "$additional_image_detected" == true ]; then
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "$IMAGE:$TAG"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE:$TAG"
+        #UNKNOWN,LOW,MEDIUM,
+        # Do not use input var TAG if not merge request
+        if [ "${{ github.event_name }}" == "pull_request" ]; then
+          module_tags=("${TAG}")
+        else
+          module_tags=(${{ github.event.repository.default_branch }})
+        fi
+
+        echo "Getting tags to scan"
+        if [ "${SCAN_THREE_LAST_RELEASES}" == "true" ]; then
+          # Get release tags by regexp, sort by sevmer desc, cut to get minor version, uniq and get 3 latest
+          latest_minor_releases=($(crane ls "${PROD_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}" | grep "v[0-9]*\." | sort -V -r | cut -d "-" -f 1|cut -d "." -f -2 | uniq| head -n 3))
+          for r in ${latest_minor_releases[*]}; do
+            module_tags+=($(crane ls "${PROD_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}" | grep "${r}" | sort -V -r|head -n 1))
+          done
+        fi
+
+        echo "CVE Scan will be applied to the following tags of ${MODULE_NAME}"
+        echo "${module_tags[*]}"
+        # Scan in loop for provided list of tags
+        for module_tag in ${module_tags[*]}; do
+          # If we are scanning release images - we need to redefine image path to prod registry
+          if [ "${module_tag}" == "${TAG}" ]; then
+            module_image="${IMAGE}"
+          # if branch is main and pipeline was triggereg by schedule or manually - use dev registry
+          elif [[ "${module_tag}" == "${{ github.event.repository.default_branch }}" ]] && [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            module_image="${DEV_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}"
           else
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "$IMAGE@$IMAGE_HASH"
-            trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "$IMAGE@$IMAGE_HASH"
+            module_image="${PROD_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}"
           fi
-          echo "    Done"
+
+          echo "Run Trivy scan"
+          echo "Image to check: "${module_image}":"${module_tag}""
+          echo "Severity: $SEVERITY"
+          echo "----------------------------------------------"
           echo ""
-          echo " Uploading trivy CVE report for image ${IMAGE_NAME} of ${MODULE_NAME} module"
-          echo ""
-          curl -s -X POST \
-            ${DD_URL}/api/v2/reimport-scan/ \
-            -H "accept: application/json" \
-            -H "Content-Type: multipart/form-data"  \
-            -H "Authorization: Token ${DD_TOKEN}" \
-            -F "auto_create_context=True" \
-            -F "minimum_severity=Info" \
-            -F "active=true" \
-            -F "verified=true" \
-            -F "scan_type=Trivy Scan" \
-            -F "close_old_findings=true" \
-            -F "do_not_reactivate=false" \
-            -F "push_to_jira=false" \
-            -F "file=@out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" \
-            -F "product_type_name=Deckhouse images" \
-            -F "product_name=$MODULE_NAME" \
-            -F "scan_date=${date_iso}" \
-            -F "engagement_name=CVE Test: ${MODULE_NAME} Images" \
-            -F "service=${MODULE_NAME} / ${IMAGE_NAME}" \
-            -F "group_by=component_name+component_version" \
-            -F "deduplication_on_engagement=false" \
-            -F "tags=deckhouse_module,module:${MODULE_NAME},image:${IMAGE_NAME},branch:${TAG}" \
-            -F "test_title=[${MODULE_NAME}]: ${IMAGE_NAME}:${TAG}" \
-            -F "version=${TAG}" \
-            -F "build_id=${IMAGE_HASH}" \
-            -F "commit_hash=${CI_COMMIT_SHA}" \
-            -F "branch_tag=${TAG}" \
-            -F "apply_tags_to_findings=true" \
-          > /dev/null
+          echo "Getting module image"
+          crane export ""${module_image}":"${module_tag}"" "${MODULE_NAME}.tar"
+          mkdir "$MODULE_NAME"
+          tar xf "${MODULE_NAME}.tar" -C "${MODULE_NAME}/"
+          echo "Preparing images list to scan"
+          digests=$(cat "${MODULE_NAME}${IMAGES_DIGESTS_PATH}")
+          # Main module images to scan
+          digests=$(echo "$digests"|jq --arg i "$MODULE_NAME" --arg s ""${module_tag}"" '. += { ($i): ($s) }')
+          echo "Images to scan:"
+          echo "$digests"
+          mkdir -p out/json
+          touch out/.trivyignore
+          date_iso=$(date -I)
+          for module_image in $(jq -rc 'to_entries[]' <<< "$digests"); do
+            IMAGE_NAME=$(jq -rc '.key' <<< "$module_image")
+            if [[ "$IMAGE_NAME" == "trivy" ]]; then
+              continue
+            fi
+            # Set flag if additional image to use tag instead of hash
+            additional_image_detected=false
+            if [ "$IMAGE_NAME" == "$MODULE_NAME" ]; then
+              additional_image_detected=true
+            fi
+            echo "----------------------------------------------"
+            echo "👾 Image: $IMAGE_NAME"
+            echo ""
+            IMAGE_HASH="$(jq -rc '.value' <<< "$module_image")"
+            IMAGE_REPORT_NAME="$MODULE_NAME::$IMAGE_NAME"
+            # Output reports per images
+            echo "    Scanning $IMAGE_REPORT_NAME"
+            if [ "$additional_image_detected" == true ]; then
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}:${module_tag}"
+            else
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}@${IMAGE_HASH}"
+            fi
+            echo "    Done"
+            echo ""
+            echo " Uploading trivy CVE report for image ${IMAGE_NAME} of ${MODULE_NAME} module"
+            echo ""
+            curl -s -X POST \
+              ${DD_URL}/api/v2/reimport-scan/ \
+              -H "accept: application/json" \
+              -H "Content-Type: multipart/form-data"  \
+              -H "Authorization: Token ${DD_TOKEN}" \
+              -F "auto_create_context=True" \
+              -F "minimum_severity=Info" \
+              -F "active=true" \
+              -F "verified=true" \
+              -F "scan_type=Trivy Scan" \
+              -F "close_old_findings=true" \
+              -F "do_not_reactivate=false" \
+              -F "push_to_jira=false" \
+              -F "file=@out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" \
+              -F "product_type_name=Deckhouse images" \
+              -F "product_name=$MODULE_NAME" \
+              -F "scan_date=${date_iso}" \
+              -F "engagement_name=CVE Test: ${MODULE_NAME} Images" \
+              -F "service=${MODULE_NAME} / ${IMAGE_NAME}" \
+              -F "group_by=component_name+component_version" \
+              -F "deduplication_on_engagement=false" \
+              -F "tags=deckhouse_module,module:${MODULE_NAME},image:${IMAGE_NAME},branch:${module_tag}" \
+              -F "test_title=[${MODULE_NAME}]: ${IMAGE_NAME}:${module_tag}" \
+              -F "version=${module_tag}" \
+              -F "build_id=${IMAGE_HASH}" \
+              -F "commit_hash=${CI_COMMIT_SHA}" \
+              -F "branch_tag=${module_tag}" \
+              -F "apply_tags_to_findings=true" \
+            > /dev/null
+          done
         done

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -37,8 +37,14 @@ inputs:
   deckhouse_private_repo:
     description: 'url to private repo'
     required: true
-  scan_three_last_releases:
-    description: 'whether to scan last 3 releases or not. useful for scheduled task'
+  scan_several_lastest_releases:
+    description: 'true/false. whether to scan last several releases or not. For scheduled pipelines it is always true'
+    required: false
+  latest_releases_amount:
+    description: 'Number of latest releases to scan. Default is: 3'
+    required: false
+  severity:
+    description: 'Vulnerabilities severity to scan. Default is: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
     required: false
 
 runs:
@@ -52,7 +58,7 @@ runs:
     - name: Get Trivy
       shell: bash
       env:
-        TRIVY_BIN_VERSION: "v0.58.1"
+        TRIVY_BIN_VERSION: "v0.60.0"
         TRIVY_REPO_ID: "2181"
         DECKHOUSE_PRIVATE_REPO: ${{inputs.deckhouse_private_repo}}
       run: |
@@ -65,7 +71,6 @@ runs:
     - name: Run Trivy CVE Scan
       shell: bash
       env:
-        SEVERITY: "HIGH,CRITICAL"
         IMAGES_DIGESTS_PATH: "/images_digests.json"
         IMAGE: "${{inputs.image}}"
         TAG: "${{inputs.tag}}"
@@ -77,20 +82,32 @@ runs:
         TRIVY_DB_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-db:2"
         TRIVY_JAVA_DB_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-java-db:1"
         TRIVY_POLICY_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-bdu:1"
+        SCAN_SEVERAL_LASTEST_RELEASES: "${{inputs.scan_several_lastest_releases}}"
+        LATEST_RELEASES_AMOUNT: "${{inputs.latest_releases_amount || '3'}}"
+        SEVERITY: "${{inputs.severity || 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'}}"
       run: |
-        #UNKNOWN,LOW,MEDIUM,
-        # Do not use input var TAG if not merge request
-        if [ "${{ github.event_name }}" == "pull_request" ]; then
-          module_tags=("${TAG}")
-        else
-          module_tags=(${{ github.event.repository.default_branch }})
+        if [ "${{ github.event_name }}" == "schedule" ]; then
+          SCAN_SEVERAL_LASTEST_RELEASES="true"
         fi
 
         echo "Getting tags to scan"
-        if [ "${{ inputs.scan_three_last_releases }}" == "true" ]; then
+        module_tags=("${TAG}")
+        # Check if provided tag for manual run is for release
+        if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "${TAG}" != "${{ github.event.repository.default_branch }}" ]; then
+            # if some specific release is defined - scan only it
+            if echo "${TAG}"|grep -q "^[0-9]*\.[0-9]*$"; then
+              module_tags=($(crane ls "${PROD_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}" | grep "^v${TAG}\.[0-9]*$" | sort -V -r | head -n 1))
+            else
+              echo "ERROR: Please specify required release in the following format: [0-9]*\.[0-9]*"
+              exit 1
+            fi
+          fi
+        fi
+        if [ "${SCAN_SEVERAL_LASTEST_RELEASES}" == "true" ]; then
           # Get release tags by regexp, sort by sevmer desc, cut to get minor version, uniq and get 3 latest
           releases=($(crane ls "${PROD_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}" | grep "^v[0-9]*\.[0-9]*\.[0-9]*" | sort -V -r))
-          latest_minor_releases=($(printf '%s\n' "${releases[@]}"| cut -d "." -f -2 | uniq | head -n 3))
+          latest_minor_releases=($(printf '%s\n' "${releases[@]}"| cut -d "." -f -2 | uniq | head -n ${LATEST_RELEASES_AMOUNT}))
           for r in "${latest_minor_releases[@]}"; do
             module_tags+=($(printf '%s\n' "${releases[@]}" | grep "${r}" | sort -V -r|head -n 1))
           done
@@ -105,7 +122,7 @@ runs:
           dd_image_version="${module_tag}"
           module_image="${DEV_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}"
           # If we are scanning release images - we need to redefine image path to prod registry
-          if echo "${module_tag}" | grep -s "^v[0-9]*\.[0-9]*\.[0-9]*" && [[ "${{ github.event_name }}" != "pull_request" ]]; then
+          if echo "${module_tag}" | grep -q "^v[0-9]*\.[0-9]*\.[0-9]*" && [[ "${{ github.event_name }}" != "pull_request" ]]; then
             module_image="${PROD_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}"
             dd_short_release_tag="release:$(echo ${module_tag} | cut -d '.' -f -2 | sed 's/^v//')"
             dd_full_release_tag="image_release_tag:${module_tag}"
@@ -118,7 +135,7 @@ runs:
           touch ${module_workdir}/.trivyignore
           echo "Run Trivy scan"
           echo "Image to check: ${module_image}:${module_tag}"
-          echo "Severity: $SEVERITY"
+          echo "Severity: ${SEVERITY}"
           echo "----------------------------------------------"
           echo ""
           echo "Getting module image"
@@ -142,26 +159,25 @@ runs:
               additional_image_detected=true
             fi
             echo "----------------------------------------------"
-            echo "👾 Image: ${IMAGE_NAME}"
+            echo "👾 Scaning image \"${IMAGE_NAME}\" of module \"${MODULE_NAME}\" for tag \"${module_tag}\""
             echo ""
             IMAGE_HASH="$(jq -rc '.value' <<< "$line")"
-            IMAGE_REPORT_NAME="${MODULE_NAME}::${IMAGE_NAME}"
-            # Output reports per images
-            echo "    Scanning $IMAGE_REPORT_NAME"
+
             if [ "$additional_image_detected" == true ]; then
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}"
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}:${module_tag}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}:${module_tag}"
             else
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}"
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}@${IMAGE_HASH}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}@${IMAGE_HASH}"
             fi
             echo "    Done"
             echo ""
             echo " Uploading trivy CVE report for image ${IMAGE_NAME} of ${MODULE_NAME} module"
             echo ""
-            curl -X POST \
-              --retry 3 \
-              --retry-delay 5 \
+            curl -f -X POST \
+              --retry 5 \
+              --retry-delay 10 \
+              --retry-all-errors \
               ${DD_URL}/api/v2/reimport-scan/ \
               -H "accept: application/json" \
               -H "Content-Type: multipart/form-data"  \

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -90,7 +90,7 @@ runs:
         echo "Get Trivy"
         echo "Trivy version: ${TRIVY_BIN_VERSION}"
         mkdir -p "${workdir}/bin/trivy-${TRIVY_BIN_VERSION}"
-        curl -s --fail-with-body https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_REPO_ID}/packages/generic/trivy-${TRIVY_BIN_VERSION}/${TRIVY_BIN_VERSION}/trivy -o ${workdir}/bin/trivy-${TRIVY_BIN_VERSION}/trivy
+        curl -L -s --fail-with-body https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_REPO_ID}/packages/generic/trivy-${TRIVY_BIN_VERSION}/${TRIVY_BIN_VERSION}/trivy -o ${workdir}/bin/trivy-${TRIVY_BIN_VERSION}/trivy
         chmod u+x ${workdir}/bin/trivy-${TRIVY_BIN_VERSION}/trivy
         ln -s ${PWD}/${workdir}/bin/trivy-${TRIVY_BIN_VERSION}/trivy ${workdir}/bin/trivy
 

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -148,11 +148,11 @@ runs:
             # Output reports per images
             echo "    Scanning $IMAGE_REPORT_NAME"
             if [ "$additional_image_detected" == true ]; then
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${IMAGE_NAME}:${module_tag}"
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${IMAGE_NAME}:${module_tag}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}:${module_tag}"
             else
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${IMAGE_NAME}@${IMAGE_HASH}"
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${IMAGE_NAME}@${IMAGE_HASH}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}@${IMAGE_HASH}"
             fi
             echo "    Done"
             echo ""

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -63,6 +63,8 @@ runs:
       env:
         TRIVY_BIN_VERSION: "v0.60.0"
         TRIVY_REPO_ID: "2181"
+        TRIVY_DB_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-db:2"
+        TRIVY_JAVA_DB_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-java-db:1"
         DECKHOUSE_PRIVATE_REPO: ${{inputs.deckhouse_private_repo}}
       run: |
         echo "Get Trivy"
@@ -86,8 +88,6 @@ runs:
         MODULE_NAME: "${{inputs.module_name}}"
         DD_URL: "${{inputs.dd_url}}"
         DD_TOKEN: "${{inputs.dd_token}}"
-        TRIVY_DB_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-db:2"
-        TRIVY_JAVA_DB_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-java-db:1"
         TRIVY_POLICY_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-bdu:1"
         SCAN_SEVERAL_LASTEST_RELEASES: "${{inputs.scan_several_lastest_releases}}"
         LATEST_RELEASES_AMOUNT: "${{inputs.latest_releases_amount || '3'}}"

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -67,11 +67,18 @@ runs:
       run: |
         echo "Get Trivy"
         echo "Trivy version: ${TRIVY_BIN_VERSION}"
-        mkdir -p bin/trivy-${TRIVY_BIN_VERSION}
+        mkdir -p cve_scan/bin/trivy-${TRIVY_BIN_VERSION}
         curl -s --fail-with-body https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_REPO_ID}/packages/generic/trivy-${TRIVY_BIN_VERSION}/${TRIVY_BIN_VERSION}/trivy -o bin/trivy-${TRIVY_BIN_VERSION}/trivy
-        chmod u+x bin/trivy-${TRIVY_BIN_VERSION}/trivy
-        echo "${PWD}/bin/trivy-${TRIVY_BIN_VERSION}" >> $GITHUB_PATH
-        bin/trivy-${TRIVY_BIN_VERSION}/trivy clean --all
+        chmod u+x cve_scan/bin/trivy-${TRIVY_BIN_VERSION}/trivy
+        echo "${PWD}/cve_scan/bin/trivy-${TRIVY_BIN_VERSION}" >> $GITHUB_PATH
+        cve_scan/bin/trivy-${TRIVY_BIN_VERSION}/trivy clean --all
+
+        echo "Updating Trivy Data Bases"
+        mkdir -p "cve_scan/bin/trivy_cache"
+        cve_scan/bin/trivy-${TRIVY_BIN_VERSION}/trivy image --download-db-only --db-repository "${TRIVY_DB_URL}" --cache-dir "cve_scan/bin/trivy_cache"
+        cve_scan/bin/trivy-${TRIVY_BIN_VERSION}/trivy image --download-java-db-only --java-db-repository "${TRIVY_JAVA_DB_URL}" --cache-dir "cve_scan/bin/trivy_cache"
+
+
     - name: Run Trivy CVE Scan
       shell: bash
       env:
@@ -174,14 +181,14 @@ runs:
 
             if [ "$additional_image_detected" == true ]; then
               if [ "${TRIVY_REPORTS_LOG_OUTPUT}" != "false" ]; then
-                trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}"
+                trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "cve_scan/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}"
               fi
-              trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}:${module_tag}"
+              trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "cve_scan/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}:${module_tag}"
             else
               if [ "${TRIVY_REPORTS_LOG_OUTPUT}" != "false" ]; then
-                trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}"
+                trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "cve_scan/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}"
               fi
-              trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}@${IMAGE_HASH}"
+              trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "cve_scan/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}@${IMAGE_HASH}"
             fi
             echo "    Done"
             echo ""

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -113,8 +113,9 @@ runs:
           module_reports="${workdir}/${MODULE_NAME}_${module_tag}/reports"
           mkdir -p "${module_workdir}"
           mkdir -p "${module_reports}"
+          touch ${module_workdir}/.trivyignore
           echo "Run Trivy scan"
-          echo "Image to check: "${module_image}:${module_tag}"
+          echo "Image to check: ${module_image}:${module_tag}"
           echo "Severity: $SEVERITY"
           echo "----------------------------------------------"
           echo ""
@@ -128,8 +129,6 @@ runs:
           digests=$(echo "$digests"|jq --arg i "$MODULE_NAME" --arg s "${module_tag}" '. += { ($i): ($s) }')
           echo "Images to scan:"
           echo "$digests"
-          mkdir -p out/json
-          touch ${module_workdir}/.trivyignore
           date_iso=$(date -I)
           while read -r line; do
             IMAGE_NAME=$(jq -rc '.key' <<< "${line}")
@@ -172,7 +171,7 @@ runs:
               -F "close_old_findings=true" \
               -F "do_not_reactivate=false" \
               -F "push_to_jira=false" \
-              -F "file=@out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" \
+              -F "file=@${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" \
               -F "product_type_name=Deckhouse images" \
               -F "product_name=$MODULE_NAME" \
               -F "scan_date=${date_iso}" \

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -108,9 +108,13 @@ runs:
           else
             module_image="${PROD_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}"
           fi
-
+          workdir="trivy_scan"
+          module_workdir="${workdir}/${MODULE_NAME}_${module_tag}"
+          module_reports="${workdir}/${MODULE_NAME}_${module_tag}/reports"
+          mkdir -p "${module_workdir}"
+          mkdir -p "${module_reports}"
           echo "Run Trivy scan"
-          echo "Image to check: "${module_image}":"${module_tag}""
+          echo "Image to check: "${module_image}:${module_tag}"
           echo "Severity: $SEVERITY"
           echo "----------------------------------------------"
           echo ""
@@ -121,39 +125,39 @@ runs:
           echo "Preparing images list to scan"
           digests=$(cat "${MODULE_NAME}${IMAGES_DIGESTS_PATH}")
           # Main module images to scan
-          digests=$(echo "$digests"|jq --arg i "$MODULE_NAME" --arg s ""${module_tag}"" '. += { ($i): ($s) }')
+          digests=$(echo "$digests"|jq --arg i "$MODULE_NAME" --arg s "${module_tag}" '. += { ($i): ($s) }')
           echo "Images to scan:"
           echo "$digests"
           mkdir -p out/json
           touch out/.trivyignore
           date_iso=$(date -I)
-          for module_image in $(jq -rc 'to_entries[]' <<< "$digests"); do
-            IMAGE_NAME=$(jq -rc '.key' <<< "$module_image")
-            if [[ "$IMAGE_NAME" == "trivy" ]]; then
+          while read -r line; do
+            IMAGE_NAME=$(jq -rc '.key' <<< "${line}")
+            if [[ "${IMAGE_NAME}" == "trivy" ]]; then
               continue
             fi
             # Set flag if additional image to use tag instead of hash
             additional_image_detected=false
-            if [ "$IMAGE_NAME" == "$MODULE_NAME" ]; then
+            if [ "$module_image" == "$MODULE_NAME" ]; then
               additional_image_detected=true
             fi
             echo "----------------------------------------------"
-            echo "👾 Image: $IMAGE_NAME"
+            echo "👾 Image: $module_image"
             echo ""
-            IMAGE_HASH="$(jq -rc '.value' <<< "$module_image")"
-            IMAGE_REPORT_NAME="$MODULE_NAME::$IMAGE_NAME"
+            IMAGE_HASH="$(jq -rc '.value' <<< "$line")"
+            IMAGE_REPORT_NAME="$MODULE_NAME::$module_image"
             # Output reports per images
             echo "    Scanning $IMAGE_REPORT_NAME"
             if [ "$additional_image_detected" == true ]; then
               trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}"
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}:${module_tag}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${module_image}_report.json" --quiet "${module_image}:${module_tag}"
             else
               trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}"
-              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}@${IMAGE_HASH}"
+              trivy i --policy "$TRIVY_POLICY_URL" --java-db-repository "$TRIVY_JAVA_DB_URL" --db-repository "$TRIVY_DB_URL" --exit-code 0 --severity "$SEVERITY" --ignorefile "out/.trivyignore" --format json --scanners vuln --output "out/json/d8_${MODULE_NAME}_${module_image}_report.json" --quiet "${module_image}@${IMAGE_HASH}"
             fi
             echo "    Done"
             echo ""
-            echo " Uploading trivy CVE report for image ${IMAGE_NAME} of ${MODULE_NAME} module"
+            echo " Uploading trivy CVE report for image ${module_image} of ${MODULE_NAME} module"
             echo ""
             curl -s -X POST \
               ${DD_URL}/api/v2/reimport-scan/ \
@@ -168,21 +172,22 @@ runs:
               -F "close_old_findings=true" \
               -F "do_not_reactivate=false" \
               -F "push_to_jira=false" \
-              -F "file=@out/json/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" \
+              -F "file=@out/json/d8_${MODULE_NAME}_${module_image}_report.json" \
               -F "product_type_name=Deckhouse images" \
               -F "product_name=$MODULE_NAME" \
               -F "scan_date=${date_iso}" \
               -F "engagement_name=CVE Test: ${MODULE_NAME} Images" \
-              -F "service=${MODULE_NAME} / ${IMAGE_NAME}" \
+              -F "service=${MODULE_NAME} / ${module_image}" \
               -F "group_by=component_name+component_version" \
               -F "deduplication_on_engagement=false" \
-              -F "tags=deckhouse_module,module:${MODULE_NAME},image:${IMAGE_NAME},branch:${module_tag}" \
-              -F "test_title=[${MODULE_NAME}]: ${IMAGE_NAME}:${module_tag}" \
+              -F "tags=deckhouse_module,module:${MODULE_NAME},image:${module_image},branch:${module_tag}" \
+              -F "test_title=[${MODULE_NAME}]: ${module_image}:${module_tag}" \
               -F "version=${module_tag}" \
               -F "build_id=${IMAGE_HASH}" \
               -F "commit_hash=${CI_COMMIT_SHA}" \
               -F "branch_tag=${module_tag}" \
               -F "apply_tags_to_findings=true" \
             > /dev/null
-          done
+          done < <(jq -rc 'to_entries[]' <<< "${digests}")
         done
+        rm -r ${workdir}

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -140,13 +140,13 @@ runs:
           dd_full_release_tag=""
           dd_image_version="${module_tag}"
           module_image="${DEV_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}"
-          trivy_registry_user="${DEV_REGISTRY_USER}"
-          trivy_registry_pass="${DEV_REGISTRY_PASSWORD}"
+          trivy_registry_user="${{inputs.dev_registry_user}}"
+          trivy_registry_pass="${{inputs.dev_registry_password}}"
           # If we are scanning release images - we need to redefine image path to prod registry
           if echo "${module_tag}" | grep -q "^v[0-9]*\.[0-9]*\.[0-9]*" && [[ "${{ github.event_name }}" != "pull_request" ]]; then
             module_image="${PROD_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}"
-            trivy_registry_user="${PROD_REGISTRY_USER}"
-            trivy_registry_pass="${PROD_REGISTRY_PASSWORD}"
+            trivy_registry_user="${{inputs.prod_registry_user}}"
+            trivy_registry_pass="${{inputs.prod_registry_password}}"
             dd_short_release_tag="release:$(echo ${module_tag} | cut -d '.' -f -2 | sed 's/^v//')"
             dd_full_release_tag="image_release_tag:${module_tag}"
             dd_image_version="$(echo ${dd_short_release_tag} | sed 's/^release\://')"

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -5,40 +5,40 @@ inputs:
     description: 'URL to a registry image, e.g., registry.example.com/deckhouse/modules/module_name'
     required: true
   tag:
-    description: 'module image tag'
+    description: 'Module image tag'
     required: true
   module_name:
-    description: 'module name'
+    description: 'Module name'
     required: true
   dd_url:
     description: 'URL to defectDojo'
     required: true
   dd_token:
-    description: 'token of defectDojo to upload reports'
+    description: 'Token of defectDojo to upload reports'
     required: true
   prod_registry:
-    description: 'must be deckhouse prod registry, used to get trivy databases and release images'
+    description: 'Must be deckhouse prod registry, used to get trivy databases and release images'
     required: true
   prod_registry_user:
-    description: 'username to log in to deckhouse prod registry'
+    description: 'Username to log in to deckhouse prod registry'
     required: true
   prod_registry_password:
-    description: 'password to log in to deckhouse prod registry'
+    description: 'Password to log in to deckhouse prod registry'
     required: true
   dev_registry:
-    description: ' must be deckhouse dev registry, used to get dev images'
+    description: 'Must be deckhouse dev registry, used to get dev images'
     required: true
   dev_registry_user:
-    description: 'username to log in to deckhouse dev registry'
+    description: 'Username to log in to deckhouse dev registry'
     required: true
   dev_registry_password:
-    description: 'password to log in to deckhouse dev registry'
+    description: 'Password to log in to deckhouse dev registry'
     required: true
   deckhouse_private_repo:
-    description: 'url to private repo'
+    description: 'URL to private repo to get Trivy from'
     required: true
   scan_several_lastest_releases:
-    description: 'true/false. whether to scan last several releases or not. For scheduled pipelines it is always true'
+    description: 'true/false. Whether to scan last several releases or not. For scheduled pipelines override will not work as value is always true'
     required: false
   latest_releases_amount:
     description: 'Number of latest releases to scan. Default is: 3'
@@ -165,10 +165,14 @@ runs:
             IMAGE_HASH="$(jq -rc '.value' <<< "$line")"
 
             if [ "$additional_image_detected" == true ]; then
-              trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}"
+              if [ "${TRIVY_REPORTS_LOG_OUTPUT}" != "false" ]; then
+                trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}"
+              fi
               trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}:${module_tag}"
             else
-              trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}"
+              if [ "${TRIVY_REPORTS_LOG_OUTPUT}" != "false" ]; then
+                trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}"
+              fi
               trivy i --policy "${TRIVY_POLICY_URL}" --java-db-repository "${TRIVY_JAVA_DB_URL}" --db-repository "${TRIVY_DB_URL}" --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}@${IMAGE_HASH}"
             fi
             echo "    Done"

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -82,8 +82,8 @@ runs:
         echo "======================================================="
         echo
         echo "Log in to registries"
-        echo ${{inputs.prod_registry_password}} | docker login --username="${{inputs.prod_registry_user}}" --password-stdin ${{inputs.prod_registry}}
-        echo ${{inputs.dev_registry_password}} | docker login --username="${{inputs.dev_registry_user}}" --password-stdin ${{inputs.dev_registry}}
+        echo "${{inputs.prod_registry_password}}" | docker login --username="${{inputs.prod_registry_user}}" --password-stdin ${{inputs.prod_registry}}
+        echo "${{inputs.dev_registry_password}}" | docker login --username="${{inputs.dev_registry_user}}" --password-stdin ${{inputs.dev_registry}}
         echo
         echo "======================================================="
         echo
@@ -96,8 +96,8 @@ runs:
 
         echo "Updating Trivy Data Bases"
         mkdir -p "${workdir}/bin/trivy_cache"
-        ${workdir}/bin/trivy image --download-db-only --db-repository "${TRIVY_DB_URL}" --cache-dir "${workdir}/bin/trivy_cache"
-        ${workdir}/bin/trivy image --download-java-db-only --java-db-repository "${TRIVY_JAVA_DB_URL}" --cache-dir "${workdir}/bin/trivy_cache"
+        ${workdir}/bin/trivy image --username "${{inputs.prod_registry_user}}" --password "${{inputs.prod_registry_password}}" --download-db-only --db-repository "${TRIVY_DB_URL}" --cache-dir "${workdir}/bin/trivy_cache"
+        ${workdir}/bin/trivy image --username "${{inputs.prod_registry_user}}" --password "${{inputs.prod_registry_password}}" --download-java-db-only --java-db-repository "${TRIVY_JAVA_DB_URL}" --cache-dir "${workdir}/bin/trivy_cache"
         echo
         echo "======================================================="
         echo
@@ -140,9 +140,13 @@ runs:
           dd_full_release_tag=""
           dd_image_version="${module_tag}"
           module_image="${DEV_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}"
+          trivy_registry_user="${DEV_REGISTRY_USER}"
+          trivy_registry_pass="${DEV_REGISTRY_PASSWORD}"
           # If we are scanning release images - we need to redefine image path to prod registry
           if echo "${module_tag}" | grep -q "^v[0-9]*\.[0-9]*\.[0-9]*" && [[ "${{ github.event_name }}" != "pull_request" ]]; then
             module_image="${PROD_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}"
+            trivy_registry_user="${PROD_REGISTRY_USER}"
+            trivy_registry_pass="${PROD_REGISTRY_PASSWORD}"
             dd_short_release_tag="release:$(echo ${module_tag} | cut -d '.' -f -2 | sed 's/^v//')"
             dd_full_release_tag="image_release_tag:${module_tag}"
             dd_image_version="$(echo ${dd_short_release_tag} | sed 's/^release\://')"
@@ -183,14 +187,14 @@ runs:
 
             if [ "$additional_image_detected" == true ]; then
               if [ "${TRIVY_REPORTS_LOG_OUTPUT}" != "false" ]; then
-                ${workdir}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "${workdir}/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}"
+                ${workdir}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "${workdir}/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}" --username "${trivy_registry_user}" --password "${trivy_registry_pass}" --image-src remote
               fi
-              ${workdir}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "${workdir}/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}:${module_tag}"
+              ${workdir}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "${workdir}/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}:${module_tag}" --username "${trivy_registry_user}" --password "${trivy_registry_pass}" --image-src remote
             else
               if [ "${TRIVY_REPORTS_LOG_OUTPUT}" != "false" ]; then
-                ${workdir}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "${workdir}/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}"
+                ${workdir}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "${workdir}/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}" --username "${trivy_registry_user}" --password "${trivy_registry_pass}" --image-src remote
               fi
-              ${workdir}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "${workdir}/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}@${IMAGE_HASH}"
+              ${workdir}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "${workdir}/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}@${IMAGE_HASH}" --username "${trivy_registry_user}" --password "${trivy_registry_pass}" --image-src remote
             fi
             echo "    Done"
             echo ""

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -87,7 +87,7 @@ runs:
         fi
 
         echo "Getting tags to scan"
-        if [ "${SCAN_THREE_LAST_RELEASES}" == "true" ]; then
+        if [ "${{ inputs.scan_three_last_releases }}" == "true" ]; then
           # Get release tags by regexp, sort by sevmer desc, cut to get minor version, uniq and get 3 latest
           latest_minor_releases=($(crane ls "${PROD_REGISTRY_MODULE_BASEDIR}/${MODULE_NAME}" | grep "v[0-9]*\." | sort -V -r | cut -d "-" -f 1|cut -d "." -f -2 | uniq| head -n 3))
           for r in ${latest_minor_releases[*]}; do
@@ -115,7 +115,7 @@ runs:
           echo "----------------------------------------------"
           echo ""
           echo "Getting module image"
-          crane export ""${module_image}":"${module_tag}"" "${MODULE_NAME}.tar"
+          crane export "${module_image}:${module_tag}" "${MODULE_NAME}.tar"
           mkdir "$MODULE_NAME"
           tar xf "${MODULE_NAME}.tar" -C "${MODULE_NAME}/"
           echo "Preparing images list to scan"

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -174,7 +174,7 @@ runs:
             echo ""
             echo " Uploading trivy CVE report for image ${IMAGE_NAME} of ${MODULE_NAME} module"
             echo ""
-            curl -f -X POST \
+            curl -s -S -o /dev/null --fail-with-body -X POST \
               --retry 5 \
               --retry-delay 10 \
               --retry-all-errors \
@@ -204,8 +204,7 @@ runs:
               -F "build_id=${IMAGE_HASH}" \
               -F "commit_hash=${CI_COMMIT_SHA}" \
               -F "branch_tag=${module_tag}" \
-              -F "apply_tags_to_findings=true" \
-            > /dev/null
+              -F "apply_tags_to_findings=true"
           done < <(jq -rc 'to_entries[]' <<< "${digests}")
         done
         rm -r ${workdir}

--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -53,12 +53,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Login to registries
-      shell: bash
-      run: |
-        echo ${{inputs.prod_registry_password}} | docker login --username="${{inputs.prod_registry_user}}" --password-stdin ${{inputs.prod_registry}}
-        echo ${{inputs.dev_registry_password}} | docker login --username="${{inputs.dev_registry_user}}" --password-stdin ${{inputs.dev_registry}}
-    - name: Get Trivy
+    - name: Run Trivy CVE Scan
       shell: bash
       env:
         TRIVY_BIN_VERSION: "v0.60.0"
@@ -66,23 +61,6 @@ runs:
         TRIVY_DB_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-db:2"
         TRIVY_JAVA_DB_URL: "${{inputs.prod_registry}}/deckhouse/ee/security/trivy-java-db:1"
         DECKHOUSE_PRIVATE_REPO: ${{inputs.deckhouse_private_repo}}
-      run: |
-        echo "Get Trivy"
-        echo "Trivy version: ${TRIVY_BIN_VERSION}"
-        mkdir -p cve_scan/bin/trivy-${TRIVY_BIN_VERSION}
-        curl -s --fail-with-body https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_REPO_ID}/packages/generic/trivy-${TRIVY_BIN_VERSION}/${TRIVY_BIN_VERSION}/trivy -o cve_scan/bin/trivy-${TRIVY_BIN_VERSION}/trivy
-        chmod u+x cve_scan/bin/trivy-${TRIVY_BIN_VERSION}/trivy
-        echo "${PWD}/cve_scan/bin/trivy-${TRIVY_BIN_VERSION}" >> $GITHUB_PATH
-
-        echo "Updating Trivy Data Bases"
-        mkdir -p "cve_scan/bin/trivy_cache"
-        cve_scan/bin/trivy-${TRIVY_BIN_VERSION}/trivy image --download-db-only --db-repository "${TRIVY_DB_URL}" --cache-dir "cve_scan/bin/trivy_cache"
-        cve_scan/bin/trivy-${TRIVY_BIN_VERSION}/trivy image --download-java-db-only --java-db-repository "${TRIVY_JAVA_DB_URL}" --cache-dir "cve_scan/bin/trivy_cache"
-
-
-    - name: Run Trivy CVE Scan
-      shell: bash
-      env:
         IMAGES_DIGESTS_PATH: "/images_digests.json"
         TAG: "${{inputs.tag}}"
         MODULE_NAME: "${{inputs.module_name}}"
@@ -95,6 +73,34 @@ runs:
         MODULE_PROD_REGISTRY_PATH: "${{inputs.module_prod_registry_custom_path || 'deckhouse/fe/modules'}}"
         MODULE_DEV_REGISTRY_PATH: "${{inputs.module_dev_registry_custom_path || 'sys/deckhouse-oss/modules'}}"
       run: |
+        echo "Creating workdir"
+        workdir="trivy_scan"
+        # remove workdir in case it was not removed on previous run
+        rm -rf "${workdir}"
+        mkdir "${workdir}"
+        echo
+        echo "======================================================="
+        echo
+        echo "Log in to registries"
+        echo ${{inputs.prod_registry_password}} | docker login --username="${{inputs.prod_registry_user}}" --password-stdin ${{inputs.prod_registry}}
+        echo ${{inputs.dev_registry_password}} | docker login --username="${{inputs.dev_registry_user}}" --password-stdin ${{inputs.dev_registry}}
+        echo
+        echo "======================================================="
+        echo
+        echo "Get Trivy"
+        echo "Trivy version: ${TRIVY_BIN_VERSION}"
+        mkdir -p "${workdir}/bin/trivy-${TRIVY_BIN_VERSION}"
+        curl -s --fail-with-body https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_REPO_ID}/packages/generic/trivy-${TRIVY_BIN_VERSION}/${TRIVY_BIN_VERSION}/trivy -o ${workdir}/bin/trivy-${TRIVY_BIN_VERSION}/trivy
+        chmod u+x ${workdir}/bin/trivy-${TRIVY_BIN_VERSION}/trivy
+        ln -s ${PWD}/${workdir}/bin/trivy-${TRIVY_BIN_VERSION}/trivy ${workdir}/bin/trivy
+
+        echo "Updating Trivy Data Bases"
+        mkdir -p "cve_scan/bin/trivy_cache"
+        ${workdir}/bin/trivy-${TRIVY_BIN_VERSION}/trivy image --download-db-only --db-repository "${TRIVY_DB_URL}" --cache-dir "${workdir}/bin/trivy_cache"
+        ${workdir}/bin/trivy-${TRIVY_BIN_VERSION}/trivy image --download-java-db-only --java-db-repository "${TRIVY_JAVA_DB_URL}" --cache-dir "${workdir}/bin/trivy_cache"
+        echo
+        echo "======================================================="
+        echo
         if [ "${{ github.event_name }}" == "schedule" ]; then
           SCAN_SEVERAL_LASTEST_RELEASES="true"
         fi
@@ -128,9 +134,6 @@ runs:
 
         echo "CVE Scan will be applied to the following tags of ${MODULE_NAME}"
         echo "${module_tags[*]}"
-        workdir="trivy_scan"
-        # remove workdir in case it was not removed on previous run
-        rm -rf "${workdir}"
         # Scan in loop for provided list of tags
         for module_tag in ${module_tags[*]}; do
           dd_short_release_tag=""
@@ -180,14 +183,14 @@ runs:
 
             if [ "$additional_image_detected" == true ]; then
               if [ "${TRIVY_REPORTS_LOG_OUTPUT}" != "false" ]; then
-                trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "cve_scan/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}"
+                ${workdir}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "${workdir}/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}:${module_tag}"
               fi
-              trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "cve_scan/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}:${module_tag}"
+              ${workdir}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "${workdir}/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}:${module_tag}"
             else
               if [ "${TRIVY_REPORTS_LOG_OUTPUT}" != "false" ]; then
-                trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "cve_scan/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}"
+                ${workdir}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "${workdir}/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format table --scanners vuln --quiet "${module_image}@${IMAGE_HASH}"
               fi
-              trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "cve_scan/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}@${IMAGE_HASH}"
+              ${workdir}/bin/trivy i --policy "${TRIVY_POLICY_URL}" --cache-dir "${workdir}/bin/trivy_cache" --skip-db-update --skip-java-db-update --exit-code 0 --severity "${SEVERITY}" --ignorefile "${module_workdir}/.trivyignore" --format json --scanners vuln --output "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" --quiet "${module_image}@${IMAGE_HASH}"
             fi
             echo "    Done"
             echo ""


### PR DESCRIPTION
Added new functionality to CVE scan for external modules:
- Ability to run by schedule to scan main and several latest minor releases with latest patch version
- Ability to run manually to scan main and latest releases or only specified release
- Tags for DefectDojo aligned to work woth rotator and reporter
- Ability to auto define registry and path of modules to scan (dev or prod) based on their tags
- Download trivy DBs moved to separate step to avoid floating trivy error and optimize scan execution
- Severity and how many releases to scan now parameterized 