### PR TITLE
curl follow redirect

### DIFF
--- a/cve_scan/action.yml
+++ b/cve_scan/action.yml
@@ -41,7 +41,7 @@ runs:
       run: |
         echo "Get Trivy"
         mkdir -p bin/trivy-${TRIVY_BIN_VERSION}
-        curl https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_REPO_ID}/packages/generic/trivy-${TRIVY_BIN_VERSION}/${TRIVY_BIN_VERSION}/trivy -o bin/trivy-${TRIVY_BIN_VERSION}/trivy
+        curl -L https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${TRIVY_REPO_ID}/packages/generic/trivy-${TRIVY_BIN_VERSION}/${TRIVY_BIN_VERSION}/trivy -o bin/trivy-${TRIVY_BIN_VERSION}/trivy
         chmod u+x bin/trivy-${TRIVY_BIN_VERSION}/trivy
         echo "${PWD}/bin/trivy-${TRIVY_BIN_VERSION}" >> $GITHUB_PATH
         bin/trivy-${TRIVY_BIN_VERSION}/trivy clean --all


### PR DESCRIPTION
Description
For some reason Trivy binary changed location in S3, so curl can not download it as it receives message "This resource has been moved temporarily to"

Why do we need it, and what problem does it solve?
Added following to redirects for curl