### PR TITLE
feat: update root version in lint action to 3

### DIFF
--- a/lint/action.yml
+++ b/lint/action.yml
@@ -9,7 +9,7 @@ runs:
       with:
         repo: dmt
         url: https://trrr.flant.dev/trdl-dmt/
-        root-version: 0
+        root-version: 3
         root-sha512: e77d785600a8c8612b84b93a5a2e4c48188d68f7478356d0708213e928bf67b024ed412e702dc32930da5c5bfc9b1c44be3ee7a292f923327815c91c6c3c3833
         group: 0
         channel: stable


### PR DESCRIPTION
Fix to the dmt version 3