### PR TITLE
fix(go_modules_check): tolerate deckhouse monorepo in go list -m all

### DIFF
--- a/go_modules_check/action.yaml
+++ b/go_modules_check/action.yaml
@@ -17,9 +17,6 @@ runs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.go_version }}
-        cache: true
-        cache-dependency-path: |
-          **/go.sum
 
     - name: Run Go modules version check
       shell: bash

--- a/go_modules_check/action.yaml
+++ b/go_modules_check/action.yaml
@@ -17,6 +17,9 @@ runs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.go_version }}
+        cache: true
+        cache-dependency-path: |
+          **/go.sum
 
     - name: Run Go modules version check
       shell: bash
@@ -27,6 +30,10 @@ runs:
           echo "Directory $search_dir does not exist."
           exit 1
         fi
+
+        # Allow loading module graph when github.com/deckhouse/deckhouse exposes in-repo
+        # submodule paths with synthetic pseudo-versions (Go 1.25+).
+        export GOFLAGS=-e
 
         temp_dir=$(mktemp -d)
         touch "$temp_dir/incorrect_alert"
@@ -59,6 +66,21 @@ runs:
                 fi
               else
                 echo "  Checking module tag $module_name"
+                # Synthetic pseudo-version used inside github.com/deckhouse/deckhouse monorepo
+                if [[ "$module_version" == "v0.0.0-00010101000000-000000000000" ]]; then
+                  echo "  Skipping placeholder module version for $module_name"
+                  continue
+                fi
+                # Transitive paths under github.com/deckhouse/deckhouse/ are not separate modules for api/* checks
+                if [[ "$module_name" == github.com/deckhouse/deckhouse/* ]]; then
+                  echo "  Skipping transitive path under github.com/deckhouse/deckhouse: $module_name"
+                  continue
+                fi
+                # Root deckhouse pin often uses vX.Y.Z-0.<time>-<hash>; only v0.0.0-<14digits>-<12hex> matches this script's api/* heuristic
+                if [[ "$module_name" == "github.com/deckhouse/deckhouse" ]] && [[ ! "$module_version" =~ ^v0\.0\.0-[0-9]{14}-[a-f0-9]{12}$ ]]; then
+                  echo "  Skipping deckhouse main module version (pseudo format not covered by api/* check): $module_version"
+                  continue
+                fi
                 repository=$(echo "$line" | awk '{print $1}' | awk -F'/' '{ print "https://"$1"/"$2"/"$3".git" }')
                 pseudo_tag=$(echo "$line" | awk '{print $2}')
                 if [[ $pseudo_tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then


### PR DESCRIPTION
## Problem

`go_modules_check` runs `go list -m all | grep deckhouse`. For modules that `require github.com/deckhouse/deckhouse`, Go 1.25+ can report transitive module lines such as `github.com/deckhouse/deckhouse/dhctl@v0.0.0-00010101000000-000000000000` that make `go list -m all` **exit non-zero**, so the composite step fails before any pseudo-tag logic.

`actions/setup-go` also warned when there is no root `go.sum` for cache.

## Change

- Set **`GOFLAGS=-e`** so the module graph loads despite those synthetic entries.
- **Skip** placeholder pseudo `v0.0.0-00010101000000-000000000000` and any `github.com/deckhouse/deckhouse/*` path (the script’s `api/*` clone heuristic does not apply to in-repo submodule paths).
- **Skip** pseudo validation for the root `github.com/deckhouse/deckhouse` require when the version is **not** `v0.0.0-<14-digit time>-<12-hex>` (the only shape this action can validate today).
- Enable Go module cache via `cache-dependency-path: **/go.sum`.

## Backport

Same commit is on `fix/go-modules-check-deckhouse-monorepo-v12` for a PR into `v12` (see separate PR).