### PR TITLE
feat: add check_previous_channel_release composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository contains GitHub Actions workflows for building and deploying mod
 | [**setup**](./setup/action.yml)       | Sets up the environment for building and deploying modules. This workflow **must** be run before any other workflows. |
 | [**build**](./build/action.yml)       | Builds the Deckhouse modules using the [werf](https://werf.io/) tool.                                                 |
 | [**deploy**](./deploy/action.yml)     | Deploys the Deckhouse modules to the one of selected release channels.                                                |
+| [**check_previous_channel_release**](./check_previous_channel_release/action.yml) | Checks that the previous release channel exposes the same module version before deploying to the next channel.        |
 | [**cve_scan**](./cve_scan/action.yml) | Trivy CVE Scan of module images. Documentation can be found [here](./.docs/cve_scan.md)                               |
 | [**svace_analyze**](./svace_analyze/action.yml) | Include svace analyze action to analyze and import builds made with svace tool  |
 | [**translate-changelog**](./translate-changelog/action.yml) | Translates Russian changelog files to English and creates a PR |

--- a/check_previous_channel_release/action.yml
+++ b/check_previous_channel_release/action.yml
@@ -1,0 +1,93 @@
+name: 'Check previous channel release'
+description: 'Check that the previous release channel exposes the same module version as the one being deployed'
+inputs:
+  module_source:
+    description: 'Registry repository address for the module, e.g., registry.example.com/deckhouse/ce/modules'
+    required: true
+  module_name:
+    description: 'Name of the module, e.g., my-module'
+    required: true
+  module_tag:
+    description: 'The version of the module to deploy to release channel, e.g., v1.21.1'
+    required: true
+  release_channel:
+    description: 'Name of the release channel. Must be one of alpha, beta, early-access, stable, rock-solid'
+    required: true
+  registry:
+    description: 'Registry URL used to read the previous release channel image'
+    required: true
+  registry_login:
+    description: 'Registry login used to read the previous release channel image (read-only is enough)'
+    required: true
+  registry_password:
+    description: 'Registry password used to read the previous release channel image (read-only is enough)'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check previous channel release for ${{ inputs.module_name }}
+      shell: bash
+      env:
+        MODULE_SOURCE: ${{ inputs.module_source }}
+        MODULE_NAME: ${{ inputs.module_name }}
+        MODULE_TAG: ${{ inputs.module_tag }}
+        RELEASE_CHANNEL: ${{ inputs.release_channel }}
+        REGISTRY: ${{ inputs.registry }}
+        REGISTRY_LOGIN: ${{ inputs.registry_login }}
+        REGISTRY_PASSWORD: ${{ inputs.registry_password }}
+      run: |
+        set -euo pipefail
+
+        echo "Module ${MODULE_NAME}, source ${MODULE_SOURCE}, channel ${RELEASE_CHANNEL}, version ${MODULE_TAG}"
+
+        case "${RELEASE_CHANNEL}" in
+          alpha)
+            echo "Deploying ${MODULE_TAG} to alpha channel, skipping previous channel check"
+            exit 0
+            ;;
+          beta)
+            previous_channel="alpha"
+            ;;
+          early-access)
+            previous_channel="beta"
+            ;;
+          stable)
+            previous_channel="early-access"
+            ;;
+          rock-solid)
+            previous_channel="stable"
+            ;;
+          *)
+            echo "Unknown channel: ${RELEASE_CHANNEL}"
+            exit 1
+            ;;
+        esac
+
+        echo "Checking previous channel ${previous_channel}"
+        crane auth login -u "${REGISTRY_LOGIN}" -p "${REGISTRY_PASSWORD}" "${REGISTRY}"
+
+        # version.json inside the release image can be either single-line
+        # ({"version":"v0.1.14"}) or pretty-printed across multiple lines
+        # ({\n  "version": "v0.1.0"\n}). Use a multiline-aware PCRE grep
+        # (-P -z) so both layouts are matched.
+        previous_channel_version=$(
+          crane export "${MODULE_SOURCE}/${MODULE_NAME}/release:${previous_channel}" - \
+            | grep -aoPz '\{\s*"version"\s*:\s*"[^"]+"\s*\}' \
+            | head -z -n 1 \
+            | tr -d '\0' \
+            | jq -r .version
+        )
+
+        if [[ -z "${previous_channel_version}" || "${previous_channel_version}" == "null" ]]; then
+          echo "Failed to read version from previous channel ${previous_channel}"
+          exit 1
+        fi
+
+        if [[ "${MODULE_TAG}" == "${previous_channel_version}" ]]; then
+          echo "Previous channel ${previous_channel} version ${previous_channel_version} is equal to desired version ${MODULE_TAG}, processing"
+          exit 0
+        else
+          echo "Previous channel ${previous_channel} version ${previous_channel_version} is not equal to desired version ${MODULE_TAG}, rejecting"
+          exit 1
+        fi


### PR DESCRIPTION
## Summary
- Adds a new composite action `check_previous_channel_release` that verifies the previous release channel exposes the same module tag before promoting to the next channel.
- Action lifts the logic previously duplicated as `.github/check_previous_channel_release.sh` in module repositories (e.g. `csi-ceph`).
- Improves the `version.json` parser so it handles both single-line (`{"version":"v0.1.14"}`) and pretty-printed multi-line output from `yq -o=json` (newlines and indentation around the keys), via a multiline-aware PCRE grep (`grep -aoPz`).
- Updates `README.md` to list the new action.

## Usage example

```yaml
- uses: deckhouse/modules-actions/setup@v14
  with:
    registry: ${{ vars.PROD_REGISTRY }}
    registry_login: ${{ vars.PROD_MODULES_REGISTRY_LOGIN }}
    registry_password: ${{ secrets.PROD_MODULES_REGISTRY_PASSWORD }}

- uses: deckhouse/modules-actions/check_previous_channel_release@v14
  with:
    module_source: "${{ vars.PROD_REGISTRY }}/${{ vars.PROD_MODULE_SOURCE_NAME }}/ce/modules"
    module_name: ${{ vars.MODULE_NAME }}
    module_tag: ${{ github.event.inputs.tag }}
    release_channel: ${{ github.event.inputs.channel }}
    registry: ${{ vars.PROD_REGISTRY }}
    registry_login: license-token
    registry_password: ${{ secrets.PROD_MODULES_READ_REGISTRY_PASSWORD }}
```

## Test plan
- [x] Locally verified the new `grep -aoPz '\{\s*"version"\s*:\s*"[^"]+"\s*\}' | head -z -n 1 | tr -d '\0' | jq -r .version` pipeline against:
  - `{"version":"v0.1.14"}`
  - pretty-printed `{\n  "version": "v0.1.0"\n}`
  - the same JSON embedded in a binary stream with NUL/non-UTF-8 bytes around it
- [ ] Smoke-test by wiring a module repo (e.g. `csi-ceph` `deploy_prod.yml`) to `check_previous_channel_release@v14` and triggering a non-alpha channel deploy.