### PR TITLE
fix(translate-changelog): translate YAML keys

### DIFF
--- a/translate-changelog/action.yml
+++ b/translate-changelog/action.yml
@@ -181,7 +181,7 @@ runs:
         translator = GoogleTranslator(source=source_lang, target=target_lang)
 
         def translate_value(value):
-            """Рекурсивно переводит значения в структуре данных"""
+            """Рекурсивно переводит строки, ключи и значения в структуре данных"""
             if isinstance(value, str):
                 # Переводим строку
                 try:
@@ -190,8 +190,10 @@ runs:
                     print(f"Warning: Failed to translate '{value[:50]}...': {e}")
                     return value
             elif isinstance(value, dict):
-                # Рекурсивно обрабатываем словарь (ключи остаются без изменений)
-                return {key: translate_value(val) for key, val in value.items()}
+                return {
+                    translate_value(key): translate_value(val)
+                    for key, val in value.items()
+                }
             elif isinstance(value, list):
                 # Рекурсивно обрабатываем список
                 return [translate_value(item) for item in value]
@@ -199,7 +201,7 @@ runs:
                 # Другие типы (числа, bool, None) возвращаем без изменений
                 return value
 
-        # Перевести все значения в структуре
+        # Перевести все ключи и значения в структуре
         translated_data = translate_value(data)
 
         # Сохранить переведенный YAML


### PR DESCRIPTION
## Summary

- `translate-changelog` now translates YAML dictionary keys as well as values (e.g. `Изменения:` → `Changes:`).
- Previously only string values were translated, so English changelog files kept Russian section headings.

## Test plan

- [ ] Push a commit that changes a `CHANGELOG/vX.Y.Z.ru.yml` file in a module using `translate-changelog@v13`.
- [ ] Verify the generated `CHANGELOG/vX.Y.Z.yml` has English keys (e.g. `Changes:`) and translated bullet text.